### PR TITLE
Fix swift2.0 warning

### DIFF
--- a/SwiftFontName/FontName.swift
+++ b/SwiftFontName/FontName.swift
@@ -510,7 +510,7 @@ extension FontName {
 
 extension FontName {
     private static func fontName(fontName name: String, osVersion version: Float? = nil) -> String {
-        if let version = version {}
+        if let _ = version {}
         return name
     }
 }


### PR DESCRIPTION
Delete unused value `version`
